### PR TITLE
Add dependency and reflection hints for producing GraalVM Native Image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,28 @@
+FROM ubuntu:23.10 AS build
+RUN apt-get update
+RUN apt-get install build-essential -y
+RUN apt-get install libz-dev -y
+RUN rm /bin/sh && ln -s /bin/bash /bin/sh
+
+# install sdkman
+RUN apt-get -qq -y install curl wget unzip zip
+RUN curl -s "https://get.sdkman.io" | bash
+RUN source "$HOME/.sdkman/bin/sdkman-init.sh" \
+    && sdk install java 22.3.r17-nik \
+    && sdk install maven 3.9.3
+
+WORKDIR buildspace
+COPY ./src src
+COPY ./pom.xml .
+
+ENV MAVEN_HOME="/root/.sdkman/candidates/maven/current"
+ENV JAVA_HOME="/root/.sdkman/candidates/java/current"
+ENV PATH="$MAVEN_HOME/bin:$JAVA_HOME/bin:$PATH"
+RUN mvn -Pnative native:compile -X
+
+# Stage 2: Package into a Docker image
+FROM debian:trixie-slim AS runtime
+RUN apt update && apt install libfreetype-dev -y
+WORKDIR /workspace
+COPY --from=build /buildspace/target/trainticket .
+CMD ["./trainticket"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
+# Stage 1: Compile the native binary
 FROM ubuntu:23.10 AS build
 RUN apt-get update
 RUN apt-get install build-essential -y

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,4 +26,5 @@ FROM debian:trixie-slim AS runtime
 RUN apt update && apt install libfreetype-dev -y
 WORKDIR /workspace
 COPY --from=build /buildspace/target/trainticket .
+EXPOSE 8080
 CMD ["./trainticket"]

--- a/pom.xml
+++ b/pom.xml
@@ -76,6 +76,12 @@
 					</excludes>
 				</configuration>
 			</plugin>
+
+			<plugin>
+				<groupId>org.graalvm.buildtools</groupId>
+				<artifactId>native-maven-plugin</artifactId>
+			</plugin>
+
 		</plugins>
 	</build>
 

--- a/src/main/java/com/guruprasad/trainticket/TrainticketApplication.java
+++ b/src/main/java/com/guruprasad/trainticket/TrainticketApplication.java
@@ -1,13 +1,76 @@
 package com.guruprasad.trainticket;
 
+import liquibase.changelog.ChangeLogHistoryServiceFactory;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.CurrentTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+import org.hibernate.generator.GeneratorCreationContext;
+import org.hibernate.generator.internal.CurrentTimestampGeneration;
+import org.springframework.aot.hint.ExecutableMode;
+import org.springframework.aot.hint.RuntimeHints;
+import org.springframework.aot.hint.RuntimeHintsRegistrar;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.ImportRuntimeHints;
+import org.springframework.util.ReflectionUtils;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Member;
+import java.util.Collections;
 
 @SpringBootApplication
+@ImportRuntimeHints(TrainticketApplication.ForBuildingNativeImage.class)
 public class TrainticketApplication {
 
 	public static void main(String[] args) {
 		SpringApplication.run(TrainticketApplication.class, args);
 	}
 
+    /*
+    There were errors seen during startup, after checking online, resolved the errors by adding the below hint registrations.
+    All hints are necessary.
+    * */
+	static class ForBuildingNativeImage implements RuntimeHintsRegistrar {
+
+		public void registerHints(RuntimeHints hints, ClassLoader classLoader) {
+
+            /* For liquibase
+            references:
+            1. https://github.com/oracle/graalvm-reachability-metadata/issues/239#issuecomment-1446033162
+            2. https://github.com/spring-projects/spring-boot/issues/38941#issuecomment-1871816760
+            * */
+			hints.resources().registerPattern("db/*.xml");
+			hints.resources().registerPattern("db/changelog/*.xml");
+			hints.reflection().registerType(ChangeLogHistoryServiceFactory.class, (type) ->
+				type.withConstructor(Collections.emptyList(), ExecutableMode.INVOKE));
+
+            /* For Hibernate
+            references:
+            1. https://stackoverflow.com/a/77791515/6241712
+            * */
+            try {
+                Constructor<CurrentTimestampGeneration> constructor1 = ReflectionUtils.accessibleConstructor(CurrentTimestampGeneration.class,
+                    CurrentTimestamp.class,
+                    Member.class,
+                    GeneratorCreationContext.class
+                );
+                Constructor<CurrentTimestampGeneration> constructor2 = ReflectionUtils.accessibleConstructor(CurrentTimestampGeneration.class,
+                    CreationTimestamp.class,
+                    Member.class,
+                    GeneratorCreationContext.class
+                );
+                Constructor<CurrentTimestampGeneration> constructor3 = ReflectionUtils.accessibleConstructor(CurrentTimestampGeneration.class,
+                    UpdateTimestamp.class,
+                    Member.class,
+                    GeneratorCreationContext.class
+                );
+
+                hints.reflection().registerConstructor(constructor1, ExecutableMode.INVOKE);
+                hints.reflection().registerConstructor(constructor2, ExecutableMode.INVOKE);
+                hints.reflection().registerConstructor(constructor3, ExecutableMode.INVOKE);
+            } catch (NoSuchMethodException nme) {
+                throw new RuntimeException(nme);
+            }
+		}
+	}
 }


### PR DESCRIPTION
GraalVM native images are guaranteed to have an extremely fast startup time.

**Details of Build and test**
The native image testing was done by producing an image with the command,
```
mvn -Pnative spring-boot:build-image
```
Which produces the image in local machine as,
```
docker.io/library/trainticket:0.0.1-SNAPSHOT
```

To run the application, the below command is used,
```
docker run -p 8080:8080 -it \
-v /home/gbhat/Projects/cloudbees_assignment/trainticket/log:/workspace/log \
docker.io/library/trainticket:0.0.1-SNAPSHOT
```
As we can see we are attaching a persistent volume endpoint to the container, this is just for the logging purpose.

However, when the application is run in a Kubernetes environment, there is no need for file-based logging. Log collection will happen with the help of agents like fluentd sidecar.

**Details of performance improvement seen**
* previous when the application was started with command `java -jar <jar file>` or through `mvn spring-boot:run` or with intellij Run configurations - the start up time seen was anywhere from **~10 seconds to 15 seconds~  4.5 seconds** (earlier startup was having issue as in #2).
* with the native image it is consistently around **275 milliseconds**.
* this means the startup time improvement seen is **~55X~ 17X**.