### PR TITLE
Workaroud #2 - Temporary patch for speeding up liquibase getLocalHostName during boot up

### DIFF
--- a/src/main/java/com/guruprasad/trainticket/TrainticketApplication.java
+++ b/src/main/java/com/guruprasad/trainticket/TrainticketApplication.java
@@ -1,24 +1,14 @@
 package com.guruprasad.trainticket;
 
-import liquibase.util.NetUtil;
+import com.guruprasad.trainticket.snippets.StaticCodeSnippets;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-
-import java.lang.reflect.Field;
 
 @SpringBootApplication
 public class TrainticketApplication {
 
-	private static void setLiquibaseNetUtilsLocalHost() throws NoSuchFieldException, IllegalAccessException {
-		Field field = NetUtil.class.getDeclaredField("hostName");
-		field.setAccessible(true);
-		field.set(null, "localhost");
-		field.setAccessible(false);
-	}
-
-	public static void main(String[] args) throws NoSuchFieldException, IllegalAccessException {
-		setLiquibaseNetUtilsLocalHost();
-
+	public static void main(String[] args) {
+		StaticCodeSnippets.setLiquibaseNetUtilsLocalHost();
 		SpringApplication.run(TrainticketApplication.class, args);
 	}
 

--- a/src/main/java/com/guruprasad/trainticket/TrainticketApplication.java
+++ b/src/main/java/com/guruprasad/trainticket/TrainticketApplication.java
@@ -1,12 +1,24 @@
 package com.guruprasad.trainticket;
 
+import liquibase.util.NetUtil;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+import java.lang.reflect.Field;
 
 @SpringBootApplication
 public class TrainticketApplication {
 
-	public static void main(String[] args) {
+	private static void setLiquibaseNetUtilsLocalHost() throws NoSuchFieldException, IllegalAccessException {
+		Field field = NetUtil.class.getDeclaredField("hostName");
+		field.setAccessible(true);
+		field.set(null, "localhost");
+		field.setAccessible(false);
+	}
+
+	public static void main(String[] args) throws NoSuchFieldException, IllegalAccessException {
+		setLiquibaseNetUtilsLocalHost();
+
 		SpringApplication.run(TrainticketApplication.class, args);
 	}
 

--- a/src/main/java/com/guruprasad/trainticket/snippets/StaticCodeSnippets.java
+++ b/src/main/java/com/guruprasad/trainticket/snippets/StaticCodeSnippets.java
@@ -1,0 +1,27 @@
+package com.guruprasad.trainticket.snippets;
+
+import liquibase.util.NetUtil;
+
+import java.lang.reflect.Field;
+
+public final class StaticCodeSnippets {
+
+    private static boolean liquibaseStuffAlreadyRan;
+
+    public static void setLiquibaseNetUtilsLocalHost() {
+        if (liquibaseStuffAlreadyRan) {
+            return;
+        }
+
+        try {
+            Field field = NetUtil.class.getDeclaredField("hostName");
+            field.setAccessible(true);
+            field.set(null, "localhost");
+            field.setAccessible(false);
+
+            liquibaseStuffAlreadyRan = true;
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,3 +1,4 @@
 spring.application.name=trainticket
+spring.h2.console.enabled=true
 spring.liquibase.enabled=true
 spring.liquibase.change-log=classpath:db/trainticket-db.xml

--- a/src/test/java/com/guruprasad/trainticket/service/UserServiceImplTest.java
+++ b/src/test/java/com/guruprasad/trainticket/service/UserServiceImplTest.java
@@ -3,6 +3,7 @@ package com.guruprasad.trainticket.service;
 import com.guruprasad.trainticket.dto.TicketReservationPayload;
 import com.guruprasad.trainticket.dto.User;
 import com.guruprasad.trainticket.repository.UserRepository;
+import com.guruprasad.trainticket.snippets.StaticCodeSnippets;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -13,6 +14,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @SpringBootTest
 class UserServiceImplTest {
+
+    UserServiceImplTest() {
+        StaticCodeSnippets.setLiquibaseNetUtilsLocalHost();
+    }
 
     @Autowired
     UserService userService;


### PR DESCRIPTION
Liquibase utils getLocalhostName as taking 10s. It is reported in a few github issues. Unfortunately at the moment it is only patched for the Mac books. Currently working around it for ubuntu with setting the private static field `hostName` directly.

With this patch, the spring application now starts up in ~4.5 seconds. Instead of previously (in general) 10+ seconds

+1 additional change -> enabling the H2 console for viewing the database tables and data easily via browser